### PR TITLE
Introduce Architectural Decision Records (ADR)

### DIFF
--- a/docs/adr/ADR-001-static-file-serving-architecture.md
+++ b/docs/adr/ADR-001-static-file-serving-architecture.md
@@ -1,0 +1,249 @@
+# ADR-001: Static File Serving Architecture
+
+**Date:** 2026-02-11
+**Status:** Proposed
+**Deciders:** Team juv25d
+**Technical Story:** Issue #18 - GET handling for static files
+
+---
+
+## Context
+
+Our HTTP server needs the ability to serve static files (HTML, CSS, JavaScript, images, etc.) to support building complete web applications. Currently, our server can parse HTTP requests and send responses, but has no mechanism to serve files from the filesystem.
+
+### Problem Statement
+
+We need to implement a static file serving mechanism that:
+- Serves files from a designated directory structure
+- Maps URLs to filesystem paths safely
+- Handles different file types with appropriate Content-Type headers
+- Provides reasonable error handling (404, 500, etc.)
+- Follows familiar conventions for ease of use
+
+### Assumptions
+
+- Static files will be bundled with the application at build time
+- Files will be served from the classpath/resources directory
+- We're building a development/learning server (not production-grade like Nginx)
+- Performance requirements are moderate (not handling thousands of requests/second)
+
+### Constraints
+
+- Must work with our existing `HttpParser`, `HttpResponse`, and `HttpResponseWriter` classes
+- Should integrate cleanly with the `SocketServer` connection handling
+- Must run inside a Docker container with resources directory available
+- Team is learning HTTP and web server concepts - architecture should be educational
+
+---
+
+## Decision
+
+We will implement a **SpringBoot-style static file serving architecture** with the following design:
+
+### Chosen Solution
+
+**1. Directory Structure:**
+```
+src/main/resources/
+└── static/
+    ├── index.html
+    ├── css/
+    │   └── styles.css
+    ├── js/
+    │   └── app.js
+    └── images/
+        └── logo.png
+```
+
+**2. URL Mapping:**
+- Files in `/resources/static/` are served at the root path
+- Example: `/resources/static/css/styles.css` → `GET /css/styles.css`
+- Root path `/` automatically serves `index.html` if it exists
+
+**3. Core Components:**
+
+```
+StaticFileHandler
+├── Validates request path (security)
+├── Maps URL to resource path
+├── Reads file from classpath
+├── Determines MIME type
+└── Creates HttpResponse with proper headers
+
+MimeTypeResolver
+└── Maps file extensions to Content-Type headers
+
+Security validator
+└── Prevents directory traversal attacks
+```
+
+**4. Security Measures:**
+- Path normalization to prevent `../` attacks
+- Whitelist only files within `/static/` directory
+- Reject paths containing `..`, absolute paths, or suspicious patterns
+- Return 403 Forbidden for security violations
+
+**5. Error Handling:**
+- 404 Not Found: File doesn't exist
+- 403 Forbidden: Security violation detected
+- 500 Internal Server Error: I/O errors
+
+**6. MIME Type Handling:**
+- Simple extension-based mapping (.html → text/html, .css → text/css, etc.)
+- Default to `application/octet-stream` for unknown types
+- Support common web file types (HTML, CSS, JS, PNG, JPG, SVG, etc.)
+
+### Why This Solution?
+
+1. **Familiar to developers:** SpringBoot convention is widely known and documented
+2. **Simple mental model:** Root path maps to `/static/` - easy to understand
+3. **Classpath-based:** Works well with JAR packaging and Docker containers
+4. **Educational:** Clear separation of concerns teaches good architecture
+5. **Extensible:** Easy to add features later (caching, compression, etc.)
+
+---
+
+## Consequences
+
+### Positive Consequences
+
+- **Developer Experience:** Developers familiar with SpringBoot will immediately understand the structure
+- **Security by Design:** Explicit security validation prevents common vulnerabilities
+- **Clean URLs:** No `/static/` prefix in URLs keeps them clean
+- **Easy Testing:** Classpath resources are easy to test with JUnit
+- **Docker-Friendly:** Resources directory is included in the container image
+- **Clear Responsibility:** `StaticFileHandler` has a single, well-defined purpose
+
+### Negative Consequences / Trade-offs
+
+- **No Dynamic Content:** This approach only handles static files (but that's the requirement)
+- **No Caching:** Every request reads from disk (acceptable for learning project)
+- **Limited Performance:** Not optimized for high-traffic scenarios
+- **Memory Usage:** Entire files loaded into memory before sending
+- **No Range Requests:** Cannot handle partial content requests (HTTP 206)
+
+### Risks
+
+- **Large Files:** Loading very large files into memory could cause issues
+    - *Mitigation:* Document file size limitations, implement streaming later if needed
+
+- **MIME Type Accuracy:** Simple extension mapping might not always be correct
+    - *Mitigation:* Cover most common web file types, extend mapping as needed
+
+- **Classpath Resources:** Files must be in classpath at runtime
+    - *Mitigation:* Clear documentation about where to place files
+
+---
+
+## Alternatives Considered
+
+### Alternative 1: Filesystem-based serving (outside classpath)
+
+**Description:** Serve files from a configurable filesystem directory outside the application.
+
+**Pros:**
+- Files can be updated without rebuilding
+- More flexible for deployment
+- Easier to handle very large files
+
+**Cons:**
+- More complex configuration
+- Path handling is platform-dependent
+- Docker volume mounting adds complexity
+- Harder to test (need actual filesystem)
+
+**Why not chosen:** Adds unnecessary complexity for a learning project. Classpath resources are simpler and work well in Docker.
+
+### Alternative 2: Embedded file map (all files in memory)
+
+**Description:** Load all static files into a HashMap at startup.
+
+**Pros:**
+- Fastest possible serving (no I/O)
+- Very simple lookup logic
+- Predictable memory usage
+
+**Cons:**
+- Cannot add files without restart
+- High memory usage for many/large files
+- Startup time increases
+- Not representative of real web servers
+
+**Why not chosen:** Not scalable and doesn't teach realistic server behavior. Reading from resources is fast enough.
+
+### Alternative 3: Show /static/ in URLs
+
+**Description:** Map `/static/file.html` → `/resources/static/file.html`
+
+**Pros:**
+- More explicit about what's being served
+- Easier to implement (direct path mapping)
+- Clear separation from dynamic routes
+
+**Cons:**
+- Less clean URLs
+- Not how SpringBoot or most frameworks work
+- Exposing internal structure in URLs
+
+**Why not chosen:** Doesn't follow common web conventions. Clean URLs are expected behavior.
+
+---
+
+## Implementation Notes
+
+### Phase 1: Core Implementation
+1. Create `StaticFileHandler` class
+2. Implement path validation and security checks
+3. Create `MimeTypeResolver` utility
+4. Integrate with existing `SocketServer` / connection handling
+5. Add unit tests for all components
+
+### Phase 2: Integration
+6. Create example static files in `/resources/static/`
+7. Update `SocketServer` to use `StaticFileHandler` for GET requests
+8. Test with browser
+9. Document usage in README
+
+### Phase 3: Polish
+10. Add logging for security violations
+11. Create custom 404 error page
+12. Add metrics/logging for file serving
+
+### Example Usage (Future):
+
+```java
+// In connection handler:
+if (request.method().equals("GET")) {
+    HttpResponse response = StaticFileHandler.handleRequest(request);
+    HttpResponseWriter.write(outputStream, response);
+}
+```
+
+### File Structure After Implementation:
+
+```
+src/main/resources/static/
+├── index.html          (served at GET /)
+├── about.html          (served at GET /about.html)
+├── css/
+│   └── styles.css      (served at GET /css/styles.css)
+└── js/
+    └── app.js          (served at GET /js/app.js)
+```
+
+---
+
+## References
+
+- [Issue #18: GET handling for static files](https://github.com/your-repo/issues/18)
+- [SpringBoot Static Content Documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/web.html#web.servlet.spring-mvc.static-content)
+- [OWASP Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
+- [MDN HTTP Content-Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type)
+- [Common MIME Types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types)
+
+---
+
+## Related ADRs
+
+- ADR-002: (Future) Caching Strategy for Static Files
+- ADR-003: (Future) Routing Architecture for Dynamic Handlers

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,93 @@
+# Architectural Decision Records (ADR)
+
+This directory contains all Architectural Decision Records for the JavaHttpServer project.
+
+## What is an ADR?
+
+An ADR is a document that captures an important architectural decision made along with its context and consequences. This helps the team:
+
+- Understand why certain design choices were made
+- Onboard new team members faster
+- Avoid repeating past discussions
+- Track the evolution of the system
+
+## ADR Format
+
+We use the format described in [Joel Parker Henderson's ADR repository](https://github.com/joelparkerhenderson/architecture-decision-record).
+
+Each ADR includes:
+- **Context:** Why the decision is needed
+- **Decision:** What choice was made
+- **Consequences:** Trade-offs, pros, and cons
+
+## Creating a New ADR
+
+1. Copy `TEMPLATE.md` to a new file named `ADR-XXX-brief-title.md` (e.g., `ADR-001-use-maven-for-build.md`)
+2. Fill in all sections of the template
+3. Discuss with the team before marking as "Accepted"
+4. Commit the ADR to the repository
+
+## Naming Convention
+
+- Files are named: `ADR-XXX-descriptive-kebab-case-title.md`
+- XXX is a zero-padded sequential number (001, 002, etc.)
+- Titles should be brief but descriptive
+
+## ADR Status
+
+An ADR can have one of the following statuses:
+
+- **Proposed:** Under discussion
+- **Accepted:** Decision has been made and is active
+- **Deprecated:** No longer relevant but kept for historical context
+- **Superseded:** Replaced by another ADR (reference the new ADR)
+
+## Index of ADRs
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [001](ADR-001-static-file-serving-architecture.md) | Static File Serving Architecture | Accepted | 2026-02-11 |
+
+---
+
+## Best Practices
+
+### When to Create an ADR
+
+Create an ADR when:
+- Making a significant architectural choice
+- Choosing between multiple viable technical solutions
+- Making a decision that will be hard to reverse
+- Implementing a pattern that the whole team should follow
+- Resolving a technical dispute
+
+### When NOT to Create an ADR
+
+Don't create ADRs for:
+- Minor code style preferences (use linting/formatting tools)
+- Trivial implementation details
+- Temporary workarounds
+- Decisions that are easily reversible
+
+### Writing Good ADRs
+
+**DO:**
+- Be specific and concrete
+- Include timestamps for time-sensitive information
+- Explain the "why" clearly
+- Consider alternatives thoroughly
+- Keep it focused on one decision
+
+**DON'T:**
+- Change existing ADRs (amend or create new ones instead)
+- Make them too long (aim for 1-2 pages)
+- Skip the "Consequences" section
+- Leave out the context
+
+---
+
+## Resources
+
+- [ADR GitHub Organization](https://adr.github.io/)
+- [Joel Parker Henderson's ADR repo](https://github.com/joelparkerhenderson/architecture-decision-record)
+- [Documenting Architecture Decisions by Michael Nygard](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,80 @@
+# ADR-XXX: [Title of Decision]
+
+**Date:** YYYY-MM-DD
+**Status:** [Proposed | Accepted | Deprecated | Superseded]
+**Deciders:** [Names of people involved]
+**Technical Story:** [Link to issue/ticket if applicable]
+
+---
+
+## Context
+
+What is the issue we're seeing that motivates this decision or change?
+
+### Problem Statement
+[Describe the problem clearly]
+
+### Assumptions
+[Any assumptions being made]
+
+### Constraints
+[Technical, time, resource constraints]
+
+---
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+### Chosen Solution
+[Describe the solution]
+
+### Why This Solution?
+[Key reasons for choosing this approach]
+
+---
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+
+### Positive Consequences
+- [benefit 1]
+- [benefit 2]
+
+### Negative Consequences / Trade-offs
+- [drawback 1]
+- [drawback 2]
+
+### Risks
+- [risk 1 and mitigation]
+
+---
+
+## Alternatives Considered
+
+### Alternative 1: [Name]
+- **Description:** [Brief description]
+- **Pros:** [List advantages]
+- **Cons:** [List disadvantages]
+- **Why not chosen:** [Reason]
+
+### Alternative 2: [Name]
+- **Description:** [Brief description]
+- **Pros:** [List advantages]
+- **Cons:** [List disadvantages]
+- **Why not chosen:** [Reason]
+
+---
+
+## Implementation Notes
+
+[Any specific implementation details, migration paths, or action items]
+
+---
+
+## References
+
+- [Link to documentation]
+- [Link to related ADRs]
+- [Link to discussion/PR]


### PR DESCRIPTION
## Changes
Closes #16

## What's Added
ADR directory structure in `/docs/adr/`  
README explaining ADR process for the team  
TEMPLATE for writing future ADRs  
ADR-001 documenting static file serving architecture

## Why This Matters
ADRs help document architectural decisions so:
- Future team members understand the "why" behind choices
- Design discussions are preserved  
- We avoid repeating past debates

## Review Focus
1. **ADR format** - Does it work for our team?
2. **ADR-001 content** - Is the static file architecture clear?
3. **Process** - Any improvements to the ADR workflow?

## Size
 Small PR: 3 markdown files

## Next Steps
After this merges, a follow-up PR will add the actual implementation 
of the static file handler documented in ADR-001.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established Architectural Decision Records (ADRs) framework for documenting design choices.
  * Added first ADR detailing static file serving architecture, covering design decisions, security considerations, error handling, and MIME type resolution.
  * Provided ADR template and guidelines for future architectural documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->