### PR TITLE
Refactor ConfigLoader to accept InputStream and add unit tests

### DIFF
--- a/src/main/java/org/juv25d/util/ConfigLoader.java
+++ b/src/main/java/org/juv25d/util/ConfigLoader.java
@@ -33,10 +33,10 @@ public class ConfigLoader {
     private void loadConfiguration(InputStream input) {
         Yaml yaml = new Yaml();
 
+        if (input == null) {
+            throw new IllegalArgumentException("Did not find application-properties.yml");
+        }
         try (input) {
-            if (input == null) {
-                throw new IllegalArgumentException("Did not find application-properties.yml");
-            }
 
             Map<String, Object> config = yaml.load(input);
             if (config == null) config = Map.of();

--- a/src/test/java/org/juv25d/util/ConfigLoaderTest.java
+++ b/src/test/java/org/juv25d/util/ConfigLoaderTest.java
@@ -3,6 +3,7 @@ package org.juv25d.util;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -26,7 +27,7 @@ class ConfigLoaderTest {
                 """;
 
         ConfigLoader loader = new ConfigLoader(
-            new ByteArrayInputStream(yaml.getBytes())
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))
         );
 
         assertEquals(9090, loader.getPort());
@@ -43,19 +44,19 @@ class ConfigLoaderTest {
     @Test
     void usesDefaultsWhenServerKeysMissing() {
         String yaml = """
-                server: {}
-                logging:
-                  level: "INFO"
-                """;
+        server: {}
+        logging: {}
+        """;
 
         ConfigLoader loader = new ConfigLoader(
-            new ByteArrayInputStream(yaml.getBytes())
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))
         );
 
         assertEquals(8080, loader.getPort());
         assertEquals("static", loader.getRootDirectory());
         assertEquals("INFO", loader.getLogLevel());
     }
+
 
     /**
      * Confirms that ConfigLoader fails predictably when no YAML configuration is provided.


### PR DESCRIPTION
This PR improves the testability and robustness of ConfigLoader by decoupling configuration parsing from file loading and adding unit tests that verify its behaviour.

The loader can now be constructed with an InputStream, making it possible to test configuration parsing without relying on classpath resources or complex classloader setups.

**Changes**

**Refactor**
- Added constructor accepting InputStream to separate I/O from parsing
- Extracted configuration loading logic into reusable method
- Introduced safe map casting helper to avoid unchecked casts
- Made numeric and string parsing more defensive (e.g. Number -> int)
- Prevents crashes on unexpected YAML structure

**Tests**
- Added unit tests verifying:
- values are correctly read from YAML input
- default values are used when server configuration keys are missing
- exception is thrown when configuration input is missing

**Result**
- No classloader hacks needed in tests
- Predictable behaviour
- Clearer error handling
- More robust parsing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust configuration loading with null-safety, clearer error reporting, and reliable defaults (port: 8080, root directory: "static", log level: "INFO").
  * Safer parsing of server, logging, and rate-limiting settings so provided values (including logging level) are applied consistently.

* **Tests**
  * Added tests covering YAML parsing, default fallbacks, and error handling for missing configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->