### PR TITLE
add .dockerignore to optimize and speed up Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+target/
+.git/
+.mvn/
+mvnw
+mvnw.cmd
+.editorconfig
+.gitignore
+*.md


### PR DESCRIPTION
**Summary**
This PR adds a .dockerignore file to the root of the project. This ensures that only necessary source files are sent to the Docker daemon during builds.

**Changes**
- Added .dockerignore to exclude:
  - taget/ (local build artifacts)
  - .git/ (git history)
  - mvnw, mvnw.cmd, .mvn/ (not needed inside the container build)
  -  other IDE-specific files