### PR TITLE
refactor: decouple Server from Pipeline by moving dependency to Conne…

### DIFF
--- a/src/main/java/org/juv25d/App.java
+++ b/src/main/java/org/juv25d/App.java
@@ -28,8 +28,7 @@ public class App {
         Server server = new Server(
             config.getPort(),
             logger,
-            handlerFactory,
-            pipeline
+            handlerFactory
         );
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {

--- a/src/main/java/org/juv25d/ConnectionHandlerFactory.java
+++ b/src/main/java/org/juv25d/ConnectionHandlerFactory.java
@@ -3,5 +3,5 @@ package org.juv25d;
 import java.net.Socket;
 
 public interface ConnectionHandlerFactory {
-    Runnable create(Socket socket, Pipeline pipeline);
+    Runnable create(Socket socket);
 }

--- a/src/main/java/org/juv25d/DefaultConnectionHandlerFactory.java
+++ b/src/main/java/org/juv25d/DefaultConnectionHandlerFactory.java
@@ -17,7 +17,7 @@ public class DefaultConnectionHandlerFactory implements ConnectionHandlerFactory
     }
 
     @Override
-    public Runnable create(Socket socket, Pipeline pipeline) {
-        return new ConnectionHandler(socket, httpParser, logger, pipeline);
+    public Runnable create(Socket socket) {
+        return new ConnectionHandler(socket, httpParser, logger, this.pipeline);
     }
 }

--- a/src/main/java/org/juv25d/Server.java
+++ b/src/main/java/org/juv25d/Server.java
@@ -9,13 +9,11 @@ public class Server {
     private final int port;
     private final Logger logger;
     private final ConnectionHandlerFactory handlerFactory;
-    private final Pipeline pipeline;
 
-    public Server(int port, Logger logger, ConnectionHandlerFactory handlerFactory, Pipeline pipeline) {
+    public Server(int port, Logger logger, ConnectionHandlerFactory handlerFactory) {
         this.port = port;
         this.logger = logger;
         this.handlerFactory = handlerFactory;
-        this.pipeline = pipeline;
     }
 
     public void start() {
@@ -24,7 +22,7 @@ public class Server {
 
             while (true) {
                 Socket socket = serverSocket.accept();
-                Runnable handler = handlerFactory.create(socket, pipeline);
+                Runnable handler = handlerFactory.create(socket);
                 Thread.ofVirtual().start(handler);
             }
 


### PR DESCRIPTION
This refactor removes the direct dependency between the Server and Pipeline to enforce a stricter request lifecycle and improve architectural separation of concerns.

Previously, the Server held a reference to the Pipeline and passed it to the ConnectionHandlerFactory. This created an unnecessary coupling between the networking layer and the request processing layer.

With this change, the DefaultConnectionHandlerFactory now owns the Pipeline dependency and is responsible for injecting it into ConnectionHandler instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined server architecture by optimizing how internal components access shared dependencies, reducing unnecessary parameter passing and improving code maintainability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->