### PR TITLE
Added docker health check and expose application port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,10 @@ FROM eclipse-temurin:25-jre-alpine
 
 WORKDIR /app
 
-# Install curl for healthcheck RUN apk add --no-cache curl
 RUN apk add --no-cache curl
 
-# Document port (optional but recommended) EXPOSE 8080
 EXPOSE 8080
 
-#Health Check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
 CMD curl -f http://localhost:8080/health || exit 1
 


### PR DESCRIPTION
Added a Docker health check to ensure the application is continuously monitored while running inside a container. The health check uses curl to call the /health endpoint at regular intervals and marks the container as healthy, starting, or unhealthy based on the response. The runtime image has been updated to include curl, and the application port is now documented using EXPOSE.

Closes #130 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured health check endpoint for improved application monitoring and availability management.
  * Standardized port 8080 configuration for consistent service deployment and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->