### PR TITLE
Feature/144 gzip compression filter

### DIFF
--- a/src/main/java/org/juv25d/config/CompressionConfig.java
+++ b/src/main/java/org/juv25d/config/CompressionConfig.java
@@ -1,12 +1,15 @@
 package org.juv25d.config;
 
+import org.juv25d.util.ConfigLoader;
+
 public class CompressionConfig {
     private final boolean enabled;
     private final int minCompressSize;
 
     public CompressionConfig() {
-        this.enabled = false;
-        this.minCompressSize = 1024;
+        ConfigLoader config = ConfigLoader.getInstance();
+        this.enabled = config.isCompressionEnabled();
+        this.minCompressSize = config.getMinCompressSize();
     }
 
     public boolean isEnabled() {

--- a/src/main/java/org/juv25d/config/CompressionConfig.java
+++ b/src/main/java/org/juv25d/config/CompressionConfig.java
@@ -1,0 +1,19 @@
+package org.juv25d.config;
+
+public class CompressionConfig {
+    private final boolean enabled;
+    private final int minCompressSize;
+
+    public CompressionConfig() {
+        this.enabled = false;
+        this.minCompressSize = 1024;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public int getMinCompressSize() {
+        return minCompressSize;
+    }
+}

--- a/src/main/java/org/juv25d/filter/CompressionFilter.java
+++ b/src/main/java/org/juv25d/filter/CompressionFilter.java
@@ -5,9 +5,13 @@ import org.juv25d.filter.annotation.Global;
 import org.juv25d.http.HttpRequest;
 import org.juv25d.logging.ServerLogging;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 
 @Global(order = 10)
@@ -38,4 +42,12 @@ public class CompressionFilter {
             .anyMatch(e -> e.equalsIgnoreCase("gzip"));
     }
 
+    private byte [] compress(byte [] data) throws IOException {
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        GZIPOutputStream gzipstream = new GZIPOutputStream(byteStream);
+
+        gzipstream.write(data);
+        gzipstream.close();
+        return byteStream.toByteArray();
+    }
 }

--- a/src/main/java/org/juv25d/filter/CompressionFilter.java
+++ b/src/main/java/org/juv25d/filter/CompressionFilter.java
@@ -1,0 +1,28 @@
+package org.juv25d.filter;
+
+import org.juv25d.config.CompressionConfig;
+import org.juv25d.filter.annotation.Global;
+import org.juv25d.logging.ServerLogging;
+
+import java.util.logging.Logger;
+
+
+@Global(order = 10)
+public class CompressionFilter {
+    private static final Logger LOGGER = ServerLogging.getLogger();
+
+    private final boolean enabled;
+    private final int minCompressSize;
+
+    public CompressionFilter() {
+        CompressionConfig config = new CompressionConfig();
+        this.enabled = config.isEnabled();
+        this.minCompressSize = config.getMinCompressSize();
+    }
+
+    public CompressionFilter(boolean enabled, int minCompressSize) {
+        this.enabled = enabled;
+        this.minCompressSize = minCompressSize;
+    }
+
+}

--- a/src/main/java/org/juv25d/filter/CompressionFilter.java
+++ b/src/main/java/org/juv25d/filter/CompressionFilter.java
@@ -40,7 +40,8 @@ public class CompressionFilter implements Filter{
             return;
         }
 
-        if (res.getHeader("Content-Encoding") != null) {
+        String existingEncoding = res.getHeader("Content-Encoding");
+        if (existingEncoding != null && !existingEncoding.isBlank()) {
             return;
         }
 
@@ -49,10 +50,12 @@ public class CompressionFilter implements Filter{
         res.setHeader("Content-Encoding", "gzip");
 
         String existingVary = res.getHeader("Vary");
-        if (existingVary != null && !existingVary.isEmpty()) {
-            res.setHeader("Vary", existingVary + ", Accept-Encoding");
-        } else {
+        if (existingVary == null || existingVary.isBlank()) {
             res.setHeader("Vary", "Accept-Encoding");
+        } else if (Arrays.stream(existingVary.split(","))
+            .map(String::trim)
+            .noneMatch(v -> v.equalsIgnoreCase("Accept-Encoding"))) {
+            res.setHeader("Vary", existingVary + ", Accept-Encoding");
         }
 
         LOGGER.info("Compressed " + body.length + " bytes to " + compressed.length + " bytes");
@@ -105,10 +108,9 @@ public class CompressionFilter implements Filter{
 
     private byte [] compress(byte [] data) throws IOException {
         ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
-        GZIPOutputStream gzipstream = new GZIPOutputStream(byteStream);
-
-        gzipstream.write(data);
-        gzipstream.close();
+        try (GZIPOutputStream gzipstream = new GZIPOutputStream(byteStream)) {
+            gzipstream.write(data);
+        }
         return byteStream.toByteArray();
     }
 }

--- a/src/main/java/org/juv25d/filter/CompressionFilter.java
+++ b/src/main/java/org/juv25d/filter/CompressionFilter.java
@@ -42,7 +42,13 @@ public class CompressionFilter implements Filter{
         byte[] compressed = compress(body);
         res.setBody(compressed);
         res.setHeader("Content-Encoding", "gzip");
-        res.setHeader("Vary", "Accept-Encoding");
+
+        String existingVary = res.getHeader("Vary");
+        if (existingVary != null && !existingVary.isEmpty()) {
+            res.setHeader("Vary", existingVary + ", Accept-Encoding");
+        } else {
+            res.setHeader("Vary", "Accept-Encoding");
+        }
 
         LOGGER.info("Compressed " + body.length + " bytes to " + compressed.length + " bytes");
     }

--- a/src/main/java/org/juv25d/filter/CompressionFilter.java
+++ b/src/main/java/org/juv25d/filter/CompressionFilter.java
@@ -2,8 +2,11 @@ package org.juv25d.filter;
 
 import org.juv25d.config.CompressionConfig;
 import org.juv25d.filter.annotation.Global;
+import org.juv25d.http.HttpRequest;
 import org.juv25d.logging.ServerLogging;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.logging.Logger;
 
 
@@ -23,6 +26,16 @@ public class CompressionFilter {
     public CompressionFilter(boolean enabled, int minCompressSize) {
         this.enabled = enabled;
         this.minCompressSize = minCompressSize;
+    }
+
+    private boolean acceptsGzip(HttpRequest req) {
+        String acceptEncoding = req.headers().get("Accept-Encoding");
+        if (acceptEncoding == null || acceptEncoding.isEmpty()) {
+            return false;
+        }
+        return Arrays.stream(acceptEncoding.split(","))
+            .map(String::trim)
+            .anyMatch(e -> e.equalsIgnoreCase("gzip"));
     }
 
 }

--- a/src/main/java/org/juv25d/filter/CompressionFilter.java
+++ b/src/main/java/org/juv25d/filter/CompressionFilter.java
@@ -79,7 +79,7 @@ public class CompressionFilter implements Filter{
         if (acceptEncoding == null || acceptEncoding.isEmpty()) {
             return false;
         }
-        
+
         return Arrays.stream(acceptEncoding.split(","))
             .map(String::trim)
             .filter(this::isGzipWithQualityAboveZero)
@@ -90,7 +90,7 @@ public class CompressionFilter implements Filter{
         String[] parts = encoding.split(";");
         String name = parts[0].trim();
         if (!name.equalsIgnoreCase("gzip")) return false;
-        
+
         if (parts.length > 1) {
             String q = parts[1].trim();
             if (q.startsWith("q=")) {

--- a/src/main/java/org/juv25d/filter/CompressionFilter.java
+++ b/src/main/java/org/juv25d/filter/CompressionFilter.java
@@ -40,6 +40,10 @@ public class CompressionFilter implements Filter{
             return;
         }
 
+        if (res.getHeader("Content-Encoding") != null) {
+            return;
+        }
+
         byte[] compressed = compress(body);
         res.setBody(compressed);
         res.setHeader("Content-Encoding", "gzip");

--- a/src/main/java/org/juv25d/filter/CompressionFilter.java
+++ b/src/main/java/org/juv25d/filter/CompressionFilter.java
@@ -9,6 +9,7 @@ import org.juv25d.logging.ServerLogging;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.logging.Logger;
 import java.util.zip.GZIPOutputStream;
 
@@ -65,12 +66,18 @@ public class CompressionFilter implements Filter{
     }
 
     private boolean acceptsGzip(HttpRequest req) {
-        String acceptEncoding = req.headers().get("Accept-Encoding");
+        String acceptEncoding = req.headers().entrySet().stream()
+            .filter(e -> e.getKey().equalsIgnoreCase("Accept-Encoding"))
+            .map(Map.Entry::getValue)
+            .findFirst()
+            .orElse(null);
+
         if (acceptEncoding == null || acceptEncoding.isEmpty()) {
             return false;
         }
         return Arrays.stream(acceptEncoding.split(","))
             .map(String::trim)
+            .map(e -> e.split(";")[0].trim())
             .anyMatch(e -> e.equalsIgnoreCase("gzip"));
     }
 

--- a/src/main/java/org/juv25d/filter/CompressionFilter.java
+++ b/src/main/java/org/juv25d/filter/CompressionFilter.java
@@ -3,23 +3,49 @@ package org.juv25d.filter;
 import org.juv25d.config.CompressionConfig;
 import org.juv25d.filter.annotation.Global;
 import org.juv25d.http.HttpRequest;
+import org.juv25d.http.HttpResponse;
 import org.juv25d.logging.ServerLogging;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.logging.Logger;
-import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 
 @Global(order = 10)
-public class CompressionFilter {
+public class CompressionFilter implements Filter{
     private static final Logger LOGGER = ServerLogging.getLogger();
 
     private final boolean enabled;
     private final int minCompressSize;
+
+    @Override
+    public void doFilter(HttpRequest req, HttpResponse res, FilterChain chain) throws IOException {
+        if (!enabled) {
+            chain.doFilter(req, res);
+            return;
+        }
+
+        if (!acceptsGzip(req)) {
+            chain.doFilter(req, res);
+            return;
+        }
+
+        chain.doFilter(req, res);
+
+        byte[] body = res.body();
+        if (body.length < minCompressSize) {
+            return;
+        }
+
+        byte[] compressed = compress(body);
+        res.setBody(compressed);
+        res.setHeader("Content-Encoding", "gzip");
+        res.setHeader("Vary", "Accept-Encoding");
+
+        LOGGER.info("Compressed " + body.length + " bytes to " + compressed.length + " bytes");
+    }
 
     public CompressionFilter() {
         CompressionConfig config = new CompressionConfig();

--- a/src/main/java/org/juv25d/filter/CompressionFilter.java
+++ b/src/main/java/org/juv25d/filter/CompressionFilter.java
@@ -79,10 +79,28 @@ public class CompressionFilter implements Filter{
         if (acceptEncoding == null || acceptEncoding.isEmpty()) {
             return false;
         }
+        
         return Arrays.stream(acceptEncoding.split(","))
             .map(String::trim)
-            .map(e -> e.split(";")[0].trim())
-            .anyMatch(e -> e.equalsIgnoreCase("gzip"));
+            .filter(this::isGzipWithQualityAboveZero)
+            .anyMatch(e -> e.split(";")[0].trim().equalsIgnoreCase("gzip"));
+    }
+
+    private boolean isGzipWithQualityAboveZero(String encoding) {
+        String[] parts = encoding.split(";");
+        String name = parts[0].trim();
+        if (!name.equalsIgnoreCase("gzip")) return false;
+        
+        if (parts.length > 1) {
+            String q = parts[1].trim();
+            if (q.startsWith("q=")) {
+                try {
+                    double quality = Double.parseDouble(q.substring(2));
+                    return quality > 0;
+                } catch (NumberFormatException ignored) {}
+            }
+        }
+        return true;
     }
 
     private byte [] compress(byte [] data) throws IOException {

--- a/src/main/java/org/juv25d/util/ConfigLoader.java
+++ b/src/main/java/org/juv25d/util/ConfigLoader.java
@@ -123,8 +123,9 @@ public class ConfigLoader {
                 this.compressionEnabled =
                     Boolean.parseBoolean(String.valueOf(compressionConfig.getOrDefault("enabled", false)));
 
-                this.minCompressSize =
+                int parsedMinCompressSize =
                     Integer.parseInt(String.valueOf(compressionConfig.getOrDefault("min-compress-size", 1024)));
+                this.minCompressSize = Math.max(0, parsedMinCompressSize);
             }
 
         } catch (Exception e) {

--- a/src/main/java/org/juv25d/util/ConfigLoader.java
+++ b/src/main/java/org/juv25d/util/ConfigLoader.java
@@ -125,7 +125,7 @@ public class ConfigLoader {
 
                 int parsedMinCompressSize =
                     Integer.parseInt(String.valueOf(compressionConfig.getOrDefault("min-compress-size", 1024)));
-                this.minCompressSize = Math.max(0, parsedMinCompressSize);
+                this.minCompressSize = Math.max(100, parsedMinCompressSize);
             }
 
         } catch (Exception e) {

--- a/src/main/java/org/juv25d/util/ConfigLoader.java
+++ b/src/main/java/org/juv25d/util/ConfigLoader.java
@@ -54,6 +54,8 @@ public class ConfigLoader {
             this.rootDirectory = "static";
             this.logLevel = "INFO";
             this.trustedProxies = List.of();
+            this.compressionEnabled = false;
+            this.minCompressSize = 1024;
 
             // server
             Object serverObj = config.get("server");
@@ -113,6 +115,16 @@ public class ConfigLoader {
 
                 this.burstCapacity =
                     Long.parseLong(String.valueOf(rateLimitingConfig.getOrDefault("burst-capacity", 100L)));
+            }
+
+            Object compressionObj = config.get("compression");
+            if (compressionObj != null) {
+                Map<String, Object> compressionConfig = asStringObjectMap(compressionObj);
+                this.compressionEnabled =
+                    Boolean.parseBoolean(String.valueOf(compressionConfig.getOrDefault("enabled", false)));
+
+                this.minCompressSize =
+                    Integer.parseInt(String.valueOf(compressionConfig.getOrDefault("min-compress-size", 1024)));
             }
 
         } catch (Exception e) {

--- a/src/main/java/org/juv25d/util/ConfigLoader.java
+++ b/src/main/java/org/juv25d/util/ConfigLoader.java
@@ -171,4 +171,12 @@ public class ConfigLoader {
     public List<ProxyRoute> getProxyRoutes() {
         return Collections.unmodifiableList(proxyRoutes);
     }
+
+    public boolean isCompressionEnabled() {
+        return compressionEnabled;
+    }
+
+    public int getMinCompressSize() {
+        return minCompressSize;
+    }
 }

--- a/src/main/java/org/juv25d/util/ConfigLoader.java
+++ b/src/main/java/org/juv25d/util/ConfigLoader.java
@@ -10,11 +10,13 @@ import java.util.*;
 public class ConfigLoader {
     @Nullable private static ConfigLoader instance;
     private int port;
+    private int minCompressSize;
     private String logLevel = "INFO";
     private String rootDirectory = "static";
     private long requestsPerMinute;
     private long burstCapacity;
     private boolean rateLimitingEnabled;
+    private boolean compressionEnabled;
     private List<String> trustedProxies;
     private List<ProxyRoute> proxyRoutes = new ArrayList<>();
 

--- a/src/main/resources/application-properties.yml
+++ b/src/main/resources/application-properties.yml
@@ -15,3 +15,7 @@ rate-limiting:
   enabled: true
   requests-per-minute: 60
   burst-capacity: 100
+
+compression:
+  enabled: true
+  min-compress-size: 1024

--- a/src/test/java/org/juv25d/filter/CompressionFilterTest.java
+++ b/src/test/java/org/juv25d/filter/CompressionFilterTest.java
@@ -104,4 +104,19 @@ public class CompressionFilterTest {
         verify(res).setBody(any(byte[].class));
         verify(res).setHeader("Content-Encoding", "gzip");
     }
+
+    @Test
+    void shouldCompress_whenBodyIsExactlyThreshold() throws IOException {
+        CompressionFilter filter = new CompressionFilter(true, 5);
+        when(req.headers()).thenReturn(Map.of(
+            "Accept-Encoding", "gzip"
+        ));
+
+        when(res.body()).thenReturn("Hello".getBytes());
+
+        filter.doFilter(req, res, chain);
+
+        verify(res).setBody(any(byte[].class));
+        verify(res).setHeader("Content-Encoding", "gzip");
+    }
 }

--- a/src/test/java/org/juv25d/filter/CompressionFilterTest.java
+++ b/src/test/java/org/juv25d/filter/CompressionFilterTest.java
@@ -73,4 +73,19 @@ public class CompressionFilterTest {
         verify(res).setHeader("Content-Encoding", "gzip");
         verify(res).setHeader("Vary", "Accept-Encoding");
     }
+
+    @Test
+    void shouldNotCompress_whenBodyIsSmallerThanThreshold() throws IOException {
+        CompressionFilter filter = new CompressionFilter(true, 1024);
+        when(req.headers()).thenReturn(Map.of(
+            "Accept-Encoding", "gzip"
+        ));
+
+        when(res.body()).thenReturn("small".getBytes());
+
+        filter.doFilter(req, res, chain);
+
+        verify(chain).doFilter(req, res);
+        verify(res, never()).setBody(any());
+    }
 }

--- a/src/test/java/org/juv25d/filter/CompressionFilterTest.java
+++ b/src/test/java/org/juv25d/filter/CompressionFilterTest.java
@@ -42,4 +42,17 @@ public class CompressionFilterTest {
         verify(chain).doFilter(req, res);
         verify(res, never()).setBody(any());
     }
+
+    @Test
+    void shouldNotCompress_whenAcceptEncodingIsNotGzip() throws IOException {
+        CompressionFilter filter = new CompressionFilter(true, 1024);
+        when(req.headers()).thenReturn(Map.of(
+            "Accept-Encoding", "deflate, br"
+        ));
+
+        filter.doFilter(req, res, chain);
+
+        verify(chain).doFilter(req, res);
+        verify(res, never()).setBody(any());
+    }
 }

--- a/src/test/java/org/juv25d/filter/CompressionFilterTest.java
+++ b/src/test/java/org/juv25d/filter/CompressionFilterTest.java
@@ -8,9 +8,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
+import java.util.Map;
 
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class CompressionFilterTest {
@@ -30,5 +30,16 @@ public class CompressionFilterTest {
 
         verify(chain).doFilter(req, res);
         verifyNoMoreInteractions(res);
+    }
+
+    @Test
+    void shouldNotCompress_whenNoAcceptEncoding() throws IOException {
+        CompressionFilter filter = new CompressionFilter(true, 1024);
+        when(req.headers()).thenReturn(Map.of());
+
+        filter.doFilter(req, res, chain);
+
+        verify(chain).doFilter(req, res);
+        verify(res, never()).setBody(any());
     }
 }

--- a/src/test/java/org/juv25d/filter/CompressionFilterTest.java
+++ b/src/test/java/org/juv25d/filter/CompressionFilterTest.java
@@ -1,0 +1,34 @@
+package org.juv25d.filter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.juv25d.http.HttpRequest;
+import org.juv25d.http.HttpResponse;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+public class CompressionFilterTest {
+
+    @Mock
+    private HttpRequest req;
+    @Mock
+    private HttpResponse res;
+    @Mock
+    private FilterChain chain;
+
+    @Test
+    void shouldNotCompress_whenDisabled() throws IOException {
+        CompressionFilter filter = new CompressionFilter(false, 1024);
+
+        filter.doFilter(req, res, chain);
+
+        verify(chain).doFilter(req, res);
+        verifyNoMoreInteractions(res);
+    }
+}

--- a/src/test/java/org/juv25d/filter/CompressionFilterTest.java
+++ b/src/test/java/org/juv25d/filter/CompressionFilterTest.java
@@ -88,4 +88,20 @@ public class CompressionFilterTest {
         verify(chain).doFilter(req, res);
         verify(res, never()).setBody(any());
     }
+
+    @Test
+    void shouldCompress_whenAcceptEncodingIsUpperCase() throws IOException {
+        CompressionFilter filter = new CompressionFilter(true, 100);
+        when(req.headers()).thenReturn(Map.of(
+            "Accept-Encoding", "GZIP"
+        ));
+
+        byte[] body = "Hello, world!".repeat(100).getBytes();
+        when(res.body()).thenReturn(body);
+
+        filter.doFilter(req, res, chain);
+
+        verify(res).setBody(any(byte[].class));
+        verify(res).setHeader("Content-Encoding", "gzip");
+    }
 }

--- a/src/test/java/org/juv25d/filter/CompressionFilterTest.java
+++ b/src/test/java/org/juv25d/filter/CompressionFilterTest.java
@@ -55,4 +55,22 @@ public class CompressionFilterTest {
         verify(chain).doFilter(req, res);
         verify(res, never()).setBody(any());
     }
+
+    @Test
+    void shouldCompress_whenAcceptEncodingIsGzip() throws IOException {
+        CompressionFilter filter = new CompressionFilter(true, 100);
+        when(req.headers()).thenReturn(Map.of(
+            "Accept-Encoding", "gzip, deflate"
+        ));
+
+        byte[] body = "Hello, world!".repeat(100).getBytes();
+        when(res.body()).thenReturn(body);
+
+        filter.doFilter(req, res, chain);
+
+        verify(chain).doFilter(req, res);
+        verify(res).setBody(any(byte[].class));
+        verify(res).setHeader("Content-Encoding", "gzip");
+        verify(res).setHeader("Vary", "Accept-Encoding");
+    }
 }

--- a/src/test/java/org/juv25d/filter/CompressionFilterTest.java
+++ b/src/test/java/org/juv25d/filter/CompressionFilterTest.java
@@ -4,12 +4,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.juv25d.http.HttpRequest;
 import org.juv25d.http.HttpResponse;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Map;
+import java.util.zip.GZIPInputStream;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -68,8 +73,10 @@ public class CompressionFilterTest {
 
         filter.doFilter(req, res, chain);
 
-        verify(chain).doFilter(req, res);
-        verify(res).setBody(any(byte[].class));
+        ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+        verify(res).setBody(captor.capture());
+        byte[] decompressed = gunzip(captor.getValue());
+        assertArrayEquals(body, decompressed);
         verify(res).setHeader("Content-Encoding", "gzip");
         verify(res).setHeader("Vary", "Accept-Encoding");
     }
@@ -101,7 +108,10 @@ public class CompressionFilterTest {
 
         filter.doFilter(req, res, chain);
 
-        verify(res).setBody(any(byte[].class));
+        ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+        verify(res).setBody(captor.capture());
+        byte[] decompressed = gunzip(captor.getValue());
+        assertArrayEquals(body, decompressed);
         verify(res).setHeader("Content-Encoding", "gzip");
     }
 
@@ -116,7 +126,49 @@ public class CompressionFilterTest {
 
         filter.doFilter(req, res, chain);
 
-        verify(res).setBody(any(byte[].class));
+        ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+        verify(res).setBody(captor.capture());
+        byte[] decompressed = gunzip(captor.getValue());
+        assertArrayEquals("Hello".getBytes(), decompressed);
         verify(res).setHeader("Content-Encoding", "gzip");
+    }
+
+    @Test
+    void shouldNotCompress_whenGzipWithQualityZero() throws IOException {
+        CompressionFilter filter = new CompressionFilter(true, 100);
+        when(req.headers()).thenReturn(Map.of(
+            "Accept-Encoding", "gzip;q=0"
+        ));
+
+        filter.doFilter(req, res, chain);
+
+        verify(chain).doFilter(req, res);
+        verify(res, never()).setBody(any());
+    }
+
+    @Test
+    void shouldCompress_whenGzipWithQualityAboveZero() throws IOException {
+        CompressionFilter filter = new CompressionFilter(true, 100);
+        when(req.headers()).thenReturn(Map.of(
+            "Accept-Encoding", "gzip;q=0.5"
+        ));
+        byte[] body = "Hello, world!".repeat(100).getBytes();
+        when(res.body()).thenReturn(body);
+
+        filter.doFilter(req, res, chain);
+
+        ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+        verify(res).setBody(captor.capture());
+        byte[] decompressed = gunzip(captor.getValue());
+        assertArrayEquals(body, decompressed);
+        verify(res).setHeader("Content-Encoding", "gzip");
+    }
+
+    private byte[] gunzip(byte[] gz) throws IOException {
+        try (GZIPInputStream in = new GZIPInputStream(new ByteArrayInputStream(gz));
+             ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            in.transferTo(out);
+            return out.toByteArray();
+        }
     }
 }


### PR DESCRIPTION
Closes #144

Implemented a CompressionFilter that compresses HTTP response bodies using GZIP encoding.

Changes:
- CompressionFilter – compresses responses when client sends Accept-Encoding: gzip
- CompressionConfig – reads compression settings from ConfigLoader
- ConfigLoader – extended with compression fields, defaults, and YAML parsing
- application-properties.yml – added compression block

Results:
- 2196 bytes → 826 bytes (62% reduction) on index page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable HTTP response compression (gzip) with enable/disable toggle and adjustable minimum size; responses that meet criteria are compressed and Content-Encoding and Vary headers updated.
  * New application configuration defaults and properties to control compression.

* **Tests**
  * Added comprehensive tests covering enabled/disabled states, Accept-Encoding variants (case and q-values), size-threshold edge cases, and header/body outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->