### PR TITLE
98 extend ipfilter functionality with subnets

### DIFF
--- a/src/main/java/org/juv25d/config/IpFilterConfig.java
+++ b/src/main/java/org/juv25d/config/IpFilterConfig.java
@@ -20,5 +20,7 @@ public class IpFilterConfig {
         return allowByDefault;
     }
 
-    public boolean trustProxyHeaders() {return trustProxyHeaders;}
+    public boolean trustProxyHeaders() {
+        return trustProxyHeaders;
+    }
 }

--- a/src/main/java/org/juv25d/filter/IpFilter.java
+++ b/src/main/java/org/juv25d/filter/IpFilter.java
@@ -44,18 +44,7 @@ public class IpFilter implements Filter {
      * @param allowByDefault whether to allow IPs not in either list
      * */
     public IpFilter(@Nullable Set<String> whitelist, @Nullable Set<String> blacklist, boolean allowByDefault) {
-        if (whitelist != null) {
-            for (String entry : whitelist) {
-                addToWhitelist(entry);
-            }
-        }
-        if (blacklist != null) {
-            for (String entry : blacklist) {
-                addToBlacklist(entry);
-            }
-        }
-        this.allowByDefault = allowByDefault;
-        this.trustProxyHeaders = false;
+        this(whitelist, blacklist, allowByDefault, false);
     }
 
     /**

--- a/src/test/java/org/juv25d/filter/IpFilterTest.java
+++ b/src/test/java/org/juv25d/filter/IpFilterTest.java
@@ -34,7 +34,7 @@ class IpFilterTest {
     @Test
     @DisplayName("Allow ip only in whitelist")
     void whitelist_allowsIp() throws IOException {
-        IpFilter filter = new IpFilter(Set.of("127.0.0.1"), null, false, false);
+        IpFilter filter = new IpFilter(Set.of("127.0.0.1"), null, false);
 
         filter.doFilter(req, res, chain);
 
@@ -91,7 +91,7 @@ class IpFilterTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Follow default when ip in neither list")
-    void Ip_inNeitherList_followsDefault(boolean allowByDefault) throws IOException {
+    void ip_inNeitherList_followsDefault(boolean allowByDefault) throws IOException {
         IpFilter filter = new IpFilter(null, null, allowByDefault);
 
         filter.doFilter(req, res, chain);


### PR DESCRIPTION
Missing last commit from #140 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for CIDR subnet ranges in IP whitelists and blacklists
  * Dynamic IP and subnet list management (add/remove at runtime)
  * Proxy header trust configuration option
  * Enhanced IP evaluation with prioritized whitelist and blacklist logic
  * Improved logging for blocked requests and proper HTTP 403 response formatting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->