### PR TITLE
Add If-Match support with 412 response for precondition failures, imp…

### DIFF
--- a/src/main/java/org/juv25d/handler/StaticFileHandler.java
+++ b/src/main/java/org/juv25d/handler/StaticFileHandler.java
@@ -77,6 +77,40 @@ public class StaticFileHandler {
 
             String etag = computeStrongEtag(fileContent);
 
+            String ifMatch = getHeaderIgnoreCase(request.headers(), "If-Match");
+            if (ifMatch != null && !ifMatch.isBlank() && !etagMatches(ifMatch, etag)) {
+                Map<String, String> headers = new HashMap<>();
+                headers.put("Content-Type", "text/html; charset=utf-8");
+                headers.put("ETag", etag);
+                headers.put("Cache-Control", "public, max-age=" + MAX_AGE_SECONDS);
+
+                String html = """
+                    <!DOCTYPE html>
+                    <html>
+                    <head>
+                        <meta charset="UTF-8">
+                        <title>412 Precondition Failed</title>
+                        <style>
+                            body {
+                                font-family: Arial, sans-serif;
+                                max-width: 600px;
+                                margin: 100px auto;
+                                text-align: center;
+                            }
+                            h1 { color: #e67e22; }
+                        </style>
+                    </head>
+                    <body>
+                        <h1>412 - Precondition Failed</h1>
+                        <p>The requested resource did not match the supplied <code>If-Match</code> precondition.</p>
+                    </body>
+                    </html>
+                    """;
+
+                logger.info("If-Match precondition failed for " + resourcePath + " -> 412 Precondition Failed");
+                return new HttpResponse(412, "Precondition Failed", headers, html.getBytes(StandardCharsets.UTF_8));
+            }
+
             String ifNoneMatch = getHeaderIgnoreCase(request.headers(), "If-None-Match");
             if (etagMatches(ifNoneMatch, etag)) {
                 Map<String, String> headers = new HashMap<>();
@@ -202,7 +236,16 @@ public class StaticFileHandler {
     @Nullable private static String opaqueTag(@Nullable String etag) {
         if (etag == null) return null;
         String e = etag.trim();
-        return e.startsWith("W/") ? e.substring(2) : e;
+
+        if (e.startsWith("W/")) {
+            e = e.substring(2).trim();
+        }
+
+        if (e.length() >= 2 && e.startsWith("\"") && e.endsWith("\"")) {
+            e = e.substring(1, e.length() - 1);
+        }
+
+        return e;
     }
 
     private static boolean etagMatches(@Nullable String ifNoneMatchHeader, String currentEtag) {
@@ -214,10 +257,15 @@ public class StaticFileHandler {
             return true;
         }
 
+        String current = opaqueTag(currentEtag);
+        if (current == null) {
+            return false;
+        }
+
         String[] parts = value.split(",");
         for (String part : parts) {
             String tag = opaqueTag(part);
-            if (part != null && tag != null && tag.equals(opaqueTag(currentEtag))) {
+            if (tag != null && tag.equals(current)) {
                 return true;
             }
         }

--- a/src/test/java/org/juv25d/handler/StaticFileHandlerTest.java
+++ b/src/test/java/org/juv25d/handler/StaticFileHandlerTest.java
@@ -77,6 +77,86 @@ class StaticFileHandlerTest {
     }
 
     @Test
+    void shouldReturn412WhenIfMatchDoesNotMatch() {
+        HttpRequest first = createRequest("GET", "/index.html");
+        HttpResponse firstResponse = StaticFileHandler.handle(first);
+
+        assertThat(firstResponse.statusCode()).isEqualTo(200);
+        String etag = firstResponse.headers().get("ETag");
+        assertThat(etag).isNotBlank();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("If-Match", "\"definitely-not-the-real-etag\"");
+
+        HttpRequest second = createRequest("GET", "/index.html", headers);
+        HttpResponse secondResponse = StaticFileHandler.handle(second);
+
+        assertThat(secondResponse.statusCode()).isEqualTo(412);
+        assertThat(secondResponse.statusText()).isEqualTo("Precondition Failed");
+        assertThat(secondResponse.headers()).containsEntry("ETag", etag);
+        assertThat(secondResponse.headers()).containsEntry("Cache-Control", "public, max-age=5");
+        assertThat(secondResponse.body()).isNotEmpty();
+    }
+
+    @Test
+    void shouldReturn200WhenIfMatchMatches() {
+        HttpRequest first = createRequest("GET", "/index.html");
+        HttpResponse firstResponse = StaticFileHandler.handle(first);
+
+        assertThat(firstResponse.statusCode()).isEqualTo(200);
+        String etag = firstResponse.headers().get("ETag");
+        assertThat(etag).isNotBlank();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("If-Match", etag);
+
+        HttpRequest second = createRequest("GET", "/index.html", headers);
+        HttpResponse secondResponse = StaticFileHandler.handle(second);
+
+        assertThat(secondResponse.statusCode()).isEqualTo(200);
+        assertThat(secondResponse.statusText()).isEqualTo("OK");
+    }
+
+    @Test
+    void shouldPreferIfMatchOverIfNoneMatch() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("If-Match", "\"nope\"");
+        headers.put("If-None-Match", "*");
+
+        HttpRequest request = createRequest("GET", "/index.html", headers);
+        HttpResponse response = StaticFileHandler.handle(request);
+
+        assertThat(response.statusCode()).isEqualTo(412);
+        assertThat(response.statusText()).isEqualTo("Precondition Failed");
+    }
+
+    @Test
+    void shouldReturn200WhenIfMatchMatchesEvenIfUnquoted() {
+        HttpRequest first = createRequest("GET", "/index.html");
+        HttpResponse firstResponse = StaticFileHandler.handle(first);
+
+        assertThat(firstResponse.statusCode()).isEqualTo(200);
+        String etag = requireHeader(firstResponse, "ETag");
+        assertThat(etag).isNotBlank();
+
+        String unquoted = etag.replace("\"", "");
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("If-Match", unquoted);
+
+        HttpRequest second = createRequest("GET", "/index.html", headers);
+        HttpResponse secondResponse = StaticFileHandler.handle(second);
+
+        assertThat(secondResponse.statusCode()).isEqualTo(200);
+        assertThat(secondResponse.statusText()).isEqualTo("OK");
+    }
+
+    private String requireHeader(HttpResponse response, String headerName) {
+        assertThat(response.headers()).containsKey(headerName);
+        return java.util.Objects.requireNonNull(response.headers().get(headerName));
+    }
+
+    @Test
     void shouldReturn404ForNonExistingFile() {
         HttpRequest request = createRequest("GET", "/nonexistent.html");
         HttpResponse response = StaticFileHandler.handle(request);


### PR DESCRIPTION
Add If-Match support with 412 response for precondition failures, improve ETag parsing. Add tests for If-Match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ETag normalization and handling for static file responses
  * Added support for HTTP If-Match preconditions with proper error responses
  * Enhanced cache validation logic for conditional requests

* **Tests**
  * Added comprehensive test coverage for ETag handling and HTTP preconditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->